### PR TITLE
Fix- reaction indices IO bug

### DIFF
--- a/lib/VFFVA.py
+++ b/lib/VFFVA.py
@@ -41,10 +41,10 @@ def VFFVA(nCores, nThreads, model, scaling=0, memAff='none', schedule='dynamic',
 
     # Set reactions to optimize
     if ex!=[]:
-        with open('rxns.csv', 'w', newline='') as myfile:
-            wr = csv.writer(myfile, quoting=csv.QUOTE_ALL)
-            wr.writerow(ex)
-        ex='rxns.csv'
+        with open('rxns.txt', 'w') as myfile:
+            for num in ex:
+                myfile.write(str(num) + "\n")   
+        ex='rxns.txt'
     else:
         ex=''
 

--- a/lib/veryfastFVA.c
+++ b/lib/veryfastFVA.c
@@ -114,7 +114,7 @@ int main (int argc, char **argv){
 	FILE *fp;
 	char fileName[100] = "output.csv";
 	char modelName[100];
-        int *rxns;
+    int *rxns;
 	
 	/*Initialize MPI*/
 	MPI_Init(&argc, &argv);
@@ -209,35 +209,33 @@ int main (int argc, char **argv){
 	/*Problem size */
 	m = CPXgetnumrows (env, lp);
 	nAll = CPXgetnumcols (env, lp);
-
         /*Rxns to optimize */
         if ( argc==5 ){
             rxns = (int*)calloc(nAll, sizeof(int));//realloc this
             int readFile=1;
             if ( readFile==1 ) {
                 FILE *fpp;
-                fpp = fopen(argv[4], "r");
-                if (fpp == NULL) {
-                    fprintf(stderr, "Error reading file\n");
-                     return 1;
-                 }
-                 char buf[2048];//realloc this
-                 n = 0;
-                 while (fgets(buf, 1024, fpp)) {
-
-                     char *field = strtok(buf, ",");
-                     while (field) {
-
-                        //printf("%s\n", field);
-                        rxns[n] = atoi(field);
-                        field   = strtok(NULL, ",");
-
-                        n++;
-                    }
-                }
-	        fclose(fpp);
+				int num, count = 0;
+				
+				fpp = fopen(argv[4], "r");
+				if (fpp == NULL) {
+					printf("Error opening file.\n");
+					return 1;
+				}
+				while (fscanf(fpp, "%d", &num) == 1) {
+					count++;
+				}
+			
+				rxns = (int *) malloc(count * sizeof(int));
+				fseek(fpp, 0, SEEK_SET);
+				
+				for (int i = 0; i < count; i++) {
+					fscanf(fpp, "%d", &rxns[i]);
+				}
+				n = count;
+				
+				fclose(fpp);
             }
-            rxns = (int *) realloc(rxns, n*sizeof(int));
         }else{
             n = nAll;
             rxns = (int*)calloc(n, sizeof(int));


### PR DESCRIPTION
This implements a fix for a bug that arrises from the way C's IO buffer reads in files with a single line. Because all reactions are written in a single line, the size of the IO buffer needs to always be _at least_ greater than or equal to the size of the line it is reading. Given that the number of reactions is not fixed (and thus the line will change in length depending on model size, # of reactions, etc), this poses as a problem due to the fact that the buffer will arbitrarily cut the line in cases where the line length is greater than the buffer size. The results in a greater # of reactions than intended, with multiple copies of different reactions being dispersed within the solution. For example, let's say you passed in a list of reactions like so- `1, 2, 3, 4, ..., 203, 204, 205, etc. `. The file **rxns.csv,** depending on the number of reactions, could be parsed to result in the following list of indices- `1, 2, 3, 4, ..., 203, 20, 4, 205, etc. `

The fix writes the reactions to a .txt file separated by newlines rather than a single line. This makes reading in the reactions a lot easier, since we can now read each line one by one without having to worry about any buffer size.

You can duplicate this bug by running VFFVA on a relatively large model and passing in a list of several hundred reaction indices to VFFVA. You will see that the number of returned reactions is larger than then number of indices you passed in. The reason this bug doesn't happen on smaller models (or on small lists of reactions), is because the line written to **rxns.csv** ends up being smaller than the size of the IO buffer, so it is quite easy to miss.