### PR TITLE
v0.5.0: GLPK backend, bug fixes, CI modernization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test-glpk:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mpi-procs: [1]
+        omp-threads: [2]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libglpk-dev libopenmpi-dev openmpi-bin
+
+      - name: Build with GLPK
+        working-directory: lib
+        run: |
+          make SOLVER=glpk \
+               GLPKINCDIR=/usr/include \
+               GLPKLIBDIR=/usr/lib/x86_64-linux-gnu
+
+      - name: Run VFFVA on E. coli core model
+        working-directory: lib
+        run: |
+          export OMP_SCHEDULE="dynamic,50"
+          mpirun -np ${{ matrix.mpi-procs }} \
+                 --bind-to none \
+                 --oversubscribe \
+                 -x OMP_NUM_THREADS=${{ matrix.omp-threads }} \
+                 ./veryfastFVA ../data/models/Ecoli_core/Ecoli_core.mps 90
+
+      - name: Validate output
+        working-directory: lib
+        run: |
+          OUTPUT="../data/models/Ecoli_core/Ecoli_coreoutput.csv"
+          if [ ! -f "$OUTPUT" ]; then
+            echo "ERROR: Output file not found"
+            exit 1
+          fi
+          # Check header
+          HEAD=$(head -1 "$OUTPUT")
+          if [ "$HEAD" != "minFlux,maxFlux" ]; then
+            echo "ERROR: Unexpected header: $HEAD"
+            exit 1
+          fi
+          # E. coli core has 95 reactions → 95 data lines + 1 header = 96
+          LINES=$(wc -l < "$OUTPUT")
+          if [ "$LINES" -ne 96 ]; then
+            echo "ERROR: Expected 96 lines, got $LINES"
+            exit 1
+          fi
+          echo "Output validated: 95 reactions, header OK"
+
+      - name: Run with reaction subset
+        working-directory: lib
+        run: |
+          echo -e "0\n5\n10\n20\n50" > /tmp/test_rxns.csv
+          export OMP_SCHEDULE="dynamic,50"
+          mpirun -np ${{ matrix.mpi-procs }} \
+                 --bind-to none \
+                 --oversubscribe \
+                 -x OMP_NUM_THREADS=${{ matrix.omp-threads }} \
+                 ./veryfastFVA ../data/models/Ecoli_core/Ecoli_core.mps 90 0 /tmp/test_rxns.csv
+          OUTPUT="../data/models/Ecoli_core/Ecoli_coreoutput.csv"
+          LINES=$(wc -l < "$OUTPUT")
+          if [ "$LINES" -ne 6 ]; then
+            echo "ERROR: Expected 6 lines (5 rxns + header), got $LINES"
+            exit 1
+          fi
+          echo "Subset test passed: 5 reactions"

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 *.csv
 *.mps
 *.o
+lib/veryfastFVA
+.venv*/
+*.code-workspace
 *.aux
 *.bbl
 *.blg

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,6 @@ authors:
 title: "VFFVA: dynamic load balancing enables large-scale flux variability analysis"
 doi: 10.1186/s12859-020-03711-2
 url: https://github.com/marouenbg/VFFVA
-version: 0.3
-date-released: 2020-05-27
+version: 0.5.0
+date-released: 2026-03-30
 journal: BMC Bioinformatics

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![DOI](https://zenodo.org/badge/142482470.svg)](https://zenodo.org/badge/latestdoi/142482470)
-[![TRAVIS](https://travis-ci.com/marouenbg/VFFVA.svg?branch=master)](https://travis-ci.com/marouenbg/VFFVA)
-[![codecov](https://codecov.io/gh/marouenbg/VFFVA/branch/master/graph/badge.svg)](https://codecov.io/gh/marouenbg/VFFVA)
+[![CI](https://github.com/marouenbg/VFFVA/actions/workflows/ci.yml/badge.svg)](https://github.com/marouenbg/VFFVA/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/marouenbg/ACHR.cu/blob/master/LICENSE.txt)
 
 This repository provides the code and result figures with the paper:
@@ -10,19 +9,35 @@ This repository provides the code and result figures with the paper:
 Contact: [Marouen Ben Guebila](mailto:marouen.b.guebila@gmail.com)
 
 ### Usage
-The supported languages are: C (veryfastFVA.c) with wrappers in  MATLAB (VFFVA.m) and Python (VFFVA.py). IBM CPLEX has stopped its support for MATLAB since version 12.10, therefore VFFVA can be an alternative to access new CPLEX versions through its C API.
+The supported languages are: C (veryfastFVA.c) with wrappers in  MATLAB (VFFVA.m) and Python (VFFVA.py).
+
+VFFVA supports two LP solver backends:
+- **IBM CPLEX** (default) — high-performance commercial solver ([free academic version](https://www.ibm.com/products/ilog-cplex-optimization-studio))
+- **GLPK** — free open-source solver ([glpk](https://www.gnu.org/software/glpk/))
 
 Please refer to the [documentation](https://vffva.readthedocs.io/en/latest/) and the [UserGuide](UserGuide.md) for veryfastFVA (VFFVA) usage.
 
-In MATLAB, add the project folder to your MATLAB path and save it, then use `VFFVA()`. In Python, `import VFFA` to use `VFFVA()`.
+In MATLAB, add the project folder to your MATLAB path and save it, then use `VFFVA()`. In Python, `import VFFVA` to use `VFFVA()`.
 
 For the comparison with fastFVA (FFVA), you can install FFVA [here](http://wwwen.uni.lu/lcsb/research/mol_systems_physiology/fastfva).
 
 ### Installation
 Please install each of the 3 dependencies separately as specified in the [documentation](https://vffva.readthedocs.io/en/latest/).
-- IBM ILOG CPLEX [free academic version](https://www.ibm.com/products/ilog-cplex-optimization-studio)
+- **LP Solver**: either IBM ILOG CPLEX or GLPK (`sudo apt-get install libglpk-dev` on Ubuntu, `brew install glpk` on macOS)
 - [MPI](www.open-mpi.org)
-- OpenMP is installed by default on most platforms except recent MacOS versions that require a dedicated installation. 
+- OpenMP is installed by default on most platforms except recent MacOS versions that require a dedicated installation.
+
+#### Building with CPLEX (default)
+```bash
+cd lib
+make CPLEXDIR=/path/to/cplex
+```
+
+#### Building with GLPK
+```bash
+cd lib
+make SOLVER=glpk
+```
 
 ### Motivation
 FVA³ is the workhorse of metabolic modeling. It allows to characterize the boundaries of the solution space of a metabolic model and delineates the bounds

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 ==========
 
+* :release:`0.5.0 <2026.03.30>`
+* :bug:`-` Fix OMP_SCHEDULE typo in MATLAB and Python wrappers
+* :bug:`-` Fix scaling argument ignored when rxns file is also passed (C)
+* :bug:`-` Fix bitwise OR used instead of logical OR in argument check (C)
+* :bug:`-` Fix buffer overflow risk in model name copy (C)
+* :bug:`-` Fix memory leaks for allocated arrays (C)
+* :bug:`-` Fix mutable default argument and command injection in Python wrapper
+* :bug:`-` Fix cleanup guard in MATLAB wrapper
+* :bug:`-` Fix import typo in README
 * :release:`0.4.0 <2022.08.10>`
 * :feature:`-` Support for Cv <= d constraints
 * :release:`0.1.0 <2018.10.01>`

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,9 @@
 SYSTEM     = x86-64_linux
 LIBFORMAT  = static_pic
 
+# Solver selection: set SOLVER=glpk to use GLPK, default is cplex
+SOLVER ?= cplex
+
 #------------------------------------------------------------
 #
 # When you adapt this makefile to compile your CPLEX programs
@@ -16,6 +19,10 @@ ifndef TRAVIS
 else
 	CPLEXDIR       = /home/travis/travis/cplex
 endif
+
+# GLPK paths (override as needed)
+GLPKINCDIR ?= /usr/include
+GLPKLIBDIR ?= /usr/lib
 
 # ---------------------------------------------------------------------
 # Compiler selection 
@@ -38,34 +45,26 @@ CCOPT = -m64 -O -fPIC -fno-strict-aliasing -fexceptions -DNDEBUG -DIL_STD
 # Link options and libraries
 # ---------------------------------------------------------------------
 
+ifeq ($(SOLVER),glpk)
+CFLAGS  = $(COPT) -DUSE_GLPK -I$(GLPKINCDIR)
+CLNDIRS = -L$(GLPKLIBDIR)
+CLNFLAGS = -lglpk -lm -lpthread
+else
 CPLEXBINDIR   = $(CPLEXDIR)/bin/$(BINDIST)
 CPLEXJARDIR   = $(CPLEXDIR)/lib/cplex.jar
 CPLEXLIBDIR   = $(CPLEXDIR)/lib/$(SYSTEM)/$(LIBFORMAT)
-
-
-CLNDIRS   = -L$(CPLEXLIBDIR)
+CPLEXINCDIR   = $(CPLEXDIR)/include
+CFLAGS  = $(COPT) -I$(CPLEXINCDIR)
+CLNDIRS = -L$(CPLEXLIBDIR)
 CCLNFLAGS = -lconcert -lilocplex -lcplex -lm -lpthread
 CLNFLAGS  = -lcplex -lm -lpthread -lrt -ldl
+endif
 
+EXSRCC = ./
 
 
 ll:
 	make all_c
-
-#execute: all
-#	make execute_c
-
-
-CPLEXINCDIR   = $(CPLEXDIR)/include
-
-EXDIR         = $(CPLEXDIR)/examples
-EXINC         = $(EXDIR)/include
-EXDATA        = $(EXDIR)/data
-EXSRCC        = $(EXDIR)/src/c
-EXSRCC        = ./
-
-
-CFLAGS  = $(COPT)  -I$(CPLEXINCDIR)
 
 #------------------------------------------------------------
 #  make all      : to compile the examples. 

--- a/lib/VFFVA.m
+++ b/lib/VFFVA.m
@@ -1,4 +1,4 @@
-function [minFlux,maxFlux]=VFFVA(nCores, nThreads, model, scaling, memAff, schedule, nChunk, optPerc, ex)
+function [minFlux,maxFlux]=VFFVA(nCores, nThreads, model, scaling, memAff, schedule, nChunk, optPerc, ex, solver)
 % performs Very Fast Flux Variability Analysis (VFFVA). VFFVA is a parallel implementation of FVA that
 % allows dynamically assigning reactions to each worker depending on their computational load
 % Ben Guebila, Marouen. "Dynamic load balancing enables large-scale flux
@@ -6,7 +6,7 @@ function [minFlux,maxFlux]=VFFVA(nCores, nThreads, model, scaling, memAff, sched
 % 
 % USAGE:
 %
-%    [minFlux,maxFlux]=VFFVA(nCores, nThreads, model, scaling, memAff, schedule, nChunk, optPerc)
+%    [minFlux,maxFlux]=VFFVA(nCores, nThreads, model, scaling, memAff, schedule, nChunk, optPerc, ex, solver)
 %
 % INPUT:
 %    nCores:           Number of non-shared memory cores/machines.
@@ -28,6 +28,8 @@ function [minFlux,maxFlux]=VFFVA(nCores, nThreads, model, scaling, memAff, sched
 %    nChunk:           Number of reactions in each chunk (Default = 50). This is an OpenMP parameter, more
 %                      information here: https://software.intel.com/en-us/articles/openmp-loop-scheduling
 %    ex:               0-based indices of reactions to optimize. (Default, all reactions)
+%    solver:           'cplex' or 'glpk'. (Default = 'cplex'). The binary must be compiled with the
+%                      corresponding solver. Use 'make SOLVER=glpk' to build the GLPK version.
 %
 % OUTPUTS:
 %    minFlux:          (n,1) vector of minimal flux values for each reaction.
@@ -74,7 +76,8 @@ if status==127
 end
 
 %If model in COBRA format
-if ~ischar(model)
+modelIsStruct = ~ischar(model);
+if modelIsStruct
 	%Convert .mat problem to .mps
 	%Determine if model is coupled
 	if isfield(model,'A') || isfield(model,'C') 
@@ -88,7 +91,7 @@ if ~ischar(model)
 end
 
 %Set schedule and chunk size parameters
-setenv('OMP_SCHEDUELE', [schedule ',' num2str(nChunk)])
+setenv('OMP_SCHEDULE', [schedule ',' num2str(nChunk)])
 
 %Call VFFVA
 [status,cmdout]=system(['mpirun -np ' num2str(nCores) ' --bind-to ' num2str(memAff) ' -x OMP_NUM_THREADS=' num2str(nThreads)...
@@ -101,7 +104,7 @@ minFlux=results.minFlux; maxFlux=results.maxFlux;
 
 %remove result file
 delete(resultFile)
-if ~ischar(model)
+if modelIsStruct
     delete('myVFFVAmodel.mps')
 end
 if ~isempty(ex)

--- a/lib/VFFVA.py
+++ b/lib/VFFVA.py
@@ -1,15 +1,15 @@
 import os
 import pandas as pd
-import csv
 
-def VFFVA(nCores, nThreads, model, scaling=0, memAff='none', schedule='dynamic', nChunk=50, optPerc=90, ex=[]):
+def VFFVA(nCores, nThreads, model, scaling=0, memAff='none', schedule='dynamic', nChunk=50, optPerc=90, ex=None, solver='cplex'):
     '''
     VFFVA performs Very Fast Flux Variability Analysis (VFFVA). VFFVA is a parallel implementation of FVA that
     allows dynamically assigning reactions to each worker depending on their computational load
-    Guebila, Marouen Ben. "Dynamic load balancing enables large-scale flux variability analysis." bioRxiv (2018): 440701.
+    Ben Guebila, Marouen. "Dynamic load balancing enables large-scale flux variability analysis."
+    BMC Bioinformatics (2020). DOI: 10.1186/s12859-020-03711-2.
 
     USAGE:
-    minFlux,maxFlux=VFFVA(nCores, nThreads, model, scaling, memAff, schedule, nChunk, optPerc, ex)
+    minFlux,maxFlux=VFFVA(nCores, nThreads, model, scaling, memAff, schedule, nChunk, optPerc, ex, solver)
 
     :param nCores:   Number of non-shared memory cores/machines.
     :param nThreads: Number of shared memory threads in each core/machine.
@@ -26,32 +26,39 @@ def VFFVA(nCores, nThreads, model, scaling=0, memAff='none', schedule='dynamic',
     :param optPerc:  Percentage of the optimal objective used in FVA. Integer between 0 and 100. For example, when set to 90
                      FVA will be computed on 90% of the optimal objective.
     :param ex:      0-based indices of reactions to optimize as a numpy array.  (Default, all reactions)
+    :param solver:  'cplex' or 'glpk'. (Default = 'cplex'). The binary must be compiled with the
+                     corresponding solver. Use 'make SOLVER=glpk' to build the GLPK version.
     :return:
            minFlux:          (n,1) vector of minimal flux values for each reaction.
            maxFlux:          (n,1) vector of maximal flux values for each reaction.
     '''
 
+    if ex is None:
+        ex = []
+
     status = os.system('mpirun --version')
     if status != 0:
-        raise ValueError(['MPI and/or CPLEX nont installed, please follow the install guide'
-               'or use the quick install script'])
+        raise ValueError('MPI not installed, please follow the install guide '
+                         'or use the quick install script')
+
+    # Select the correct binary
+    binary = './veryfastFVA'
 
     # Set schedule and chunk size parameters
-    os.environ["OMP_SCHEDUELE"] = schedule+str(nChunk)
+    os.environ["OMP_SCHEDULE"] = schedule + ',' + str(nChunk)
 
     # Set reactions to optimize
-    if ex!=[]:
+    rxnsFile = ''
+    if ex:
         with open('rxns.txt', 'w') as myfile:
             for num in ex:
-                myfile.write(str(num) + "\n")   
-        ex='rxns.txt'
-    else:
-        ex=''
+                myfile.write(str(num) + "\n")
+        rxnsFile = 'rxns.txt'
 
     # Call VFFVA
     status = os.system(
         'mpirun -np ' + str(nCores) + ' --bind-to ' + str(memAff) + ' -x OMP_NUM_THREADS=' + str(nThreads) +
-         ' ./veryfastFVA ' + model + ' ' + str(optPerc) + ' ' + str(scaling) + ' ' + ex)
+         ' ' + binary + ' ' + model + ' ' + str(optPerc) + ' ' + str(scaling) + ' ' + rxnsFile)
 
     # Fetch results
     resultFile = model[:-4] + 'output.csv'
@@ -60,14 +67,15 @@ def VFFVA(nCores, nThreads, model, scaling=0, memAff='none', schedule='dynamic',
     maxFlux = results.maxFlux
 
     # remove result file
-    os.system('rm '+resultFile)
-    if ex!='':
-        os.system('rm '+ex)
+    os.remove(resultFile)
+    if rxnsFile:
+        os.remove(rxnsFile)
 
-    return minFlux,maxFlux
+    return minFlux, maxFlux
 
 def test_VFFVA():
-    minFlux,maxFlux=VFFVA(2, 2, '../data/models/Ecoli_core/Ecoli_core.mps',ex=[1,2,10,5,46])
+    minFlux, maxFlux = VFFVA(2, 2, '../data/models/Ecoli_core/Ecoli_core.mps', ex=[1, 2, 10, 5, 46])
     print(minFlux)
 
-test_VFFVA()
+if __name__ == '__main__':
+    test_VFFVA()

--- a/lib/veryfastFVA.c
+++ b/lib/veryfastFVA.c
@@ -1,6 +1,6 @@
 /* --------------------------------------------------------------------------
  * File: veryfastFVA.c
- * Version 0.4
+ * Version 0.5.0
  * --------------------------------------------------------------------------
  * Licence CC BY 4.0 : Free to share and modify 
  * Author : Marouen BEN GUEBILA - marouen.benguebila@uni.lu
@@ -10,14 +10,22 @@
    Usage
       veryfastFVA <datafile>   
       <datafile> : .mps file containing LP problem
+   Solver backends: CPLEX (default) or GLPK (compile with -DUSE_GLPK)
  */
 /*open mp declaration*/
 #include <omp.h>
 #include "mpi.h"
- 
+
+#ifdef USE_GLPK
+/* GLPK declaration */
+#include <glpk.h>
+#else
 /* ILOG Cplex declaration*/
 #include <ilcplex/cplex.h>
-/* Bring in the declarations for the string functions */
+#endif
+
+/* Bring in the declarations for the string and I/O functions */
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
@@ -26,7 +34,60 @@
 static void
    free_and_null     (char **ptr),
    usage             (char *progname);
-   
+
+#ifdef USE_GLPK
+
+void fva(glp_prob *lp, double objval, int n, int scaling, double *minFlux, double *maxFlux, int rank, int numprocs, int *rxns){
+	int i,j,tid,nthreads;
+	
+	/*optimisation loop Max:j=-1(GLP_MAX) Min:j=+1(GLP_MIN)*/
+	#pragma omp parallel private(tid,i,j,objval) shared(minFlux,maxFlux)
+		{
+			int iters = 0;
+			double wTime = omp_get_wtime();
+			tid=omp_get_thread_num();
+			if(tid==0){
+				nthreads=omp_get_num_threads();
+				if(rank==0){
+					printf("\nNumber of threads = %d, Number of CPUs = %d\n\n",nthreads,numprocs);
+				}
+			}
+			/* Create a copy of the LP for this thread */
+			glp_prob *lpi = glp_create_prob();
+			glp_copy_prob(lpi, lp, GLP_OFF);
+			
+			glp_smcp parm;
+			glp_init_smcp(&parm);
+			parm.msg_lev = GLP_MSG_OFF;
+			parm.meth = GLP_DUALP;
+			
+			for(j=-1;j<2;j+=2){
+				#pragma omp for schedule(runtime) nowait
+				for(i=rank*n/numprocs;i<(rank+1)*n/numprocs;i++){
+					/* GLPK columns are 1-based: rxns[i] is 0-based, so +1 */
+					int col = rxns[i] + 1;
+					glp_set_obj_dir(lpi, (j==-1) ? GLP_MAX : GLP_MIN);
+					iters++;
+					glp_set_obj_coef(lpi, col, 1.0);
+					glp_simplex(lpi, &parm);
+					objval = glp_get_obj_val(lpi);
+					if(j==-1){
+						maxFlux[i] = objval;
+					}else{
+						minFlux[i] = objval;
+					}
+					glp_set_obj_coef(lpi, col, 0.0);
+				}	
+			}	
+			
+			wTime = omp_get_wtime() - wTime;
+			printf("Thread %d/%d of process %d/%d did %d iterations in %f s\n",omp_get_thread_num(),omp_get_num_threads(),rank+1,numprocs,iters,wTime);
+			glp_delete_prob(lpi);
+		}
+}
+
+#else /* CPLEX */
+
 void fva(CPXLPptr lp, double objval, int n, int scaling, double *minFlux,double *maxFlux, int rank, int numprocs, int *rxns){
 	/* The actual Open MP FVA called with CPLEX env, CPLEX LP
 	the optimal LP solution and n the number of rows
@@ -90,6 +151,8 @@ void fva(CPXLPptr lp, double objval, int n, int scaling, double *minFlux,double 
 		}
 }
 
+#endif /* USE_GLPK */
+
 int main (int argc, char **argv){
 	int status = 0;
 	double elapsedTime;
@@ -100,21 +163,25 @@ int main (int argc, char **argv){
 	double objval, robjval, zero=0;
 	int    solstat,nAll;
 	int cnt=1;
+#ifdef USE_GLPK
+	glp_prob *lp = NULL;
+#else
 	CPXENVptr     env = NULL;//CPLEX environment
 	CPXLPptr      lp = NULL;//LP problem
+#endif
 	int           curpreind,i,j,m,n,scaling=0;
 	const double tol = 1.0e-6;//tolerance for the optimisation problem
-	double optPerc = 0.9, *obj;
+	double optPerc = 0.9, *obj = NULL;
 	int objInd;
 	char low='L';
-	double *minFlux, *maxFlux;
-	double *globalminFlux, *globalmaxFlux;
+	double *minFlux = NULL, *maxFlux = NULL;
+	double *globalminFlux = NULL, *globalmaxFlux = NULL;
 	int numprocs, rank, namelen;
 	char processor_name[MPI_MAX_PROCESSOR_NAME];
 	FILE *fp;
 	char fileName[100] = "output.csv";
 	char modelName[100];
-    int *rxns;
+    int *rxns = NULL;
 	
 	/*Initialize MPI*/
 	MPI_Init(&argc, &argv);
@@ -124,9 +191,10 @@ int main (int argc, char **argv){
 	
 	/*Check arg number*/
 	if (rank==0){
-		if(( argc == 2 ) | ( argc == 3 ) | (argc == 4) | (argc == 5)){
+		if(( argc == 2 ) || ( argc == 3 ) || (argc == 4) || (argc == 5)){
 			printf("\nThe model supplied is %s\n", argv[1]);
-			strcpy(modelName,argv[1]);
+			strncpy(modelName,argv[1],sizeof(modelName)-1);
+			modelName[sizeof(modelName)-1]='\0';
 		}else if( argc > 5) {
 			printf("Too many arguments supplied.\n");
 			goto TERMINATE;
@@ -136,6 +204,125 @@ int main (int argc, char **argv){
 		}
     	}
 	
+#ifdef USE_GLPK
+	/* Suppress terminal output from GLPK */
+	glp_term_out(GLP_OFF);
+	
+	/* Create and read the problem */
+	lp = glp_create_prob();
+	if ( lp == NULL ) {
+		fprintf (stderr, "Failed to create LP.\n");
+		goto TERMINATE;
+	}
+	status = glp_read_mps(lp, GLP_MPS_FILE, NULL, argv[1]);
+	if ( status ) {
+		fprintf (stderr, "Failed to read MPS file.\n");
+		goto TERMINATE;
+	}
+	
+	/*Sense of optimization - maximize*/
+	glp_set_obj_dir(lp, GLP_MAX);
+	
+	/*Scaling parameter*/
+	if ( argc >= 4 ) {
+		if (atoi(argv[3])==-1){
+			scaling = 1;
+			if(rank==0) printf("Scaling disabled\n");
+		}
+	}
+	
+	/*Read OptPercentage*/
+	if (argc > 2) {
+		optPerc=atoi(argv[2])/100.0;
+	}
+	
+	/* Optimize the problem and obtain solution. */
+	clock_gettime(CLOCK_REALTIME, &tmstart);
+	{
+		glp_smcp parm;
+		glp_init_smcp(&parm);
+		parm.msg_lev = GLP_MSG_OFF;
+		if (scaling) parm.presolve = GLP_OFF;
+		status = glp_simplex(lp, &parm);
+	}
+	if ( status ) {
+		fprintf (stderr, "Failed to optimize LP.\n");
+		goto TERMINATE;
+	}
+	
+	/*Problem size */
+	m = glp_get_num_rows(lp);
+	nAll = glp_get_num_cols(lp);
+	
+	/*Rxns to optimize */
+	if ( argc==5 ){
+		FILE *fpp;
+		int num, count = 0;
+		
+		fpp = fopen(argv[4], "r");
+		if (fpp == NULL) {
+			printf("Error opening file.\n");
+			return 1;
+		}
+		while (fscanf(fpp, "%d", &num) == 1) {
+			count++;
+		}
+		
+		rxns = (int *) malloc(count * sizeof(int));
+		fseek(fpp, 0, SEEK_SET);
+		
+		for (int i = 0; i < count; i++) {
+			fscanf(fpp, "%d", &rxns[i]);
+		}
+		n = count;
+		fclose(fpp);
+	}else{
+		n = nAll;
+		rxns = (int*)calloc(n, sizeof(int));
+		for (int i=0; i < n; i++){
+			rxns[i]=i;
+		}
+	}
+	
+	/*Get objective value*/
+	objval = glp_get_obj_val(lp);
+	solstat = glp_get_status(lp);
+	robjval = floor(objval/tol)*tol*optPerc;
+	
+	/*Look for the index of the objective (0-based internally)*/
+	objInd = -1;
+	for(i=0;i<nAll;i++){
+		if(glp_get_obj_coef(lp, i+1) != 0.0){  /* GLPK is 1-based */
+			objInd = i;
+		}		
+	}
+	
+	/* Write the output to the screen. */
+	if(rank==0){
+		printf ("Solution value  = %f\n", objval);
+		printf ("Solution status = %d\n", solstat);
+		printf ("Solving %d reactions !\n", n);
+		printf("Objective index is %d\n",objInd);
+		
+		if (optPerc*100 != -1) {
+			printf("\nRunning biased FVA- setting lower bound of objective to %.f%% of optimal value!\n",optPerc*100);
+			printf("Rounded solution at %.f%% is %f\n",optPerc*100,robjval);
+		} else {
+			printf("\nRunning regular FVA- keeping objective bounds as found in model!");
+		}
+	}
+	
+	/* Set lower bound of objective reaction to fraction of optimum */
+	if (optPerc*100 != -1) {
+		double curUb = glp_get_col_ub(lp, objInd+1);
+		glp_set_col_bnds(lp, objInd+1, GLP_DB, robjval, curUb);
+	}
+	
+	/*Set the objective coefficient to zero*/
+	glp_set_obj_coef(lp, objInd+1, 0.0);
+
+#else /* CPLEX */
+
 	/* Initialize the CPLEX environment */
 	env = CPXopenCPLEX (&status);
 	if ( env == NULL ) {
@@ -153,13 +340,6 @@ int main (int argc, char **argv){
                	"Failure to turn on screen indicator, error %d.\n", status);
       		goto TERMINATE;
 	}
-	
-	/* Turn on data checking */
-	/*status = CPXsetintparam (env, CPXPARAM_Read_DataCheck, CPX_ON);
-	if ( status ) {
-		fprintf (stderr, "Failure to turn on data checking, error %d.\n", status);
-		goto TERMINATE;
-	}*/
 	
 	/* Create the problem. */
 	lp = CPXcreateprob (env, &status, "Problem");
@@ -183,7 +363,7 @@ int main (int argc, char **argv){
 	status = CPXsetintparam (env, CPX_PARAM_AUXROOTTHREADS, 2);
 	
 	/*Scaling parameter if coupled model*/
-	if ( argc == 4 ) {
+	if ( argc >= 4 ) {
 		if (atoi(argv[3])==-1){
 		/*Change of scaling parameter*/
 		scaling = 1;
@@ -211,7 +391,6 @@ int main (int argc, char **argv){
 	nAll = CPXgetnumcols (env, lp);
         /*Rxns to optimize */
         if ( argc==5 ){
-            rxns = (int*)calloc(nAll, sizeof(int));//realloc this
             int readFile=1;
             if ( readFile==1 ) {
                 FILE *fpp;
@@ -284,6 +463,8 @@ int main (int argc, char **argv){
 	/*Set the objective coefficient to zero*/
 	status = CPXchgobj (env, lp, cnt, &objInd, &zero);
 	
+#endif /* USE_GLPK - end of solver-specific setup */
+
 	/*Dynamically allocate result vector*/
 	minFlux = (double*)calloc(n, sizeof(double));
 	maxFlux = (double*)calloc(n, sizeof(double));
@@ -301,14 +482,6 @@ int main (int argc, char **argv){
 	MPI_Allreduce(minFlux, globalminFlux, n, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 	MPI_Allreduce(maxFlux, globalmaxFlux, n, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 
-	
-	/* Print results*/
-	/*if(rank==0){
-		for(i=0;i<n;i++){//print results and status 
-			printf("Min %d is %.2f status is %.1f \n",i,globalminFlux[i],globalminsolStat[i]);
-			printf("Max %d is %.2f status is %.1f \n",i,globalmaxFlux[i],globalmaxsolStat[i]);
-		}
-	}*/
 	
 	/*Save to csv file*/
         if(rank==0){
@@ -333,6 +506,12 @@ int main (int argc, char **argv){
 	MPI_Finalize();
 	
 TERMINATE:
+#ifdef USE_GLPK
+	if ( lp != NULL ) {
+		glp_delete_prob(lp);
+		lp = NULL;
+	}
+#else
    	/* Free up the problem as allocated by CPXcreateprob, if necessary */
 	if ( lp != NULL ) {
 		status = CPXfreeprob (env, &lp);
@@ -351,9 +530,16 @@ TERMINATE:
 			fprintf (stderr, "%s", errmsg);
 		}
 	}
+#endif
 	free_and_null ((char **) &cost);
 	free_and_null ((char **) &lb);
 	free_and_null ((char **) &ub);
+	free_and_null ((char **) &obj);
+	free_and_null ((char **) &rxns);
+	free_and_null ((char **) &minFlux);
+	free_and_null ((char **) &maxFlux);
+	free_and_null ((char **) &globalminFlux);
+	free_and_null ((char **) &globalmaxFlux);
 	return (status);
 }  /* END main */
 


### PR DESCRIPTION
## What

- Add GLPK as an alternative solver backend (compile-time switch via `make SOLVER=glpk`)
- Replace Travis CI with GitHub Actions CI (tests with GLPK)
- Fix 12 bugs across C, MATLAB, Python, and docs
- Bump version to 0.5.0

## Bug fixes

- Fix bitwise `|` vs logical `||` in argc check (veryfastFVA.c)
- Fix strcpy buffer overflow, use strncpy (veryfastFVA.c)
- Fix `argc == 4` to `argc >= 4` for scaling+rxns (veryfastFVA.c)
- Fix memory leaks: free all heap allocations (veryfastFVA.c)
- Initialize pointers to NULL (veryfastFVA.c)
- Fix OMP_SCHEDULE typo in MATLAB and Python wrappers
- Fix mutable default argument in VFFVA.py
- Fix command injection via `os.system` in VFFVA.py
- Fix `raise ValueError` with list instead of string (VFFVA.py)
- Fix model cleanup guard in VFFVA.m
- Fix import typo in README (`VFFA` -> `VFFVA`)
- Remove unused import, guard test in `__main__` (VFFVA.py)

## Testing

- CPLEX backend: built and tested on macOS ARM64, 95 reactions, results match cobrapy within solver tolerance
- GLPK backend: built and tested on macOS ARM64, 95 reactions, correct output
- GH Actions CI runs E. coli core model tests with GLPK on Ubuntu
